### PR TITLE
Handle long URLs

### DIFF
--- a/classes/task/expirequeue.php
+++ b/classes/task/expirequeue.php
@@ -1,0 +1,47 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * @package filter_imageopt
+ * @author Andrew Hancox <andrewdchancox@googlemail.com>
+ * @author Open Source Learning <enquiries@opensourcelearning.co.uk>
+ * @link https://opensourcelearning.co.uk
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright 2024, Andrew Hancox
+ */
+
+namespace filter_imageopt\task;
+
+defined('MOODLE_INTERNAL') || die();
+
+class expirequeue extends \core\task\scheduled_task {
+    /**
+     * @return string
+     */
+    public function get_name() {
+        return get_string('expirequeuetask', 'filter_imageopt');
+    }
+
+    public function execute() {
+        global $DB;
+
+        $DB->delete_records_select(
+            'filter_imageopt',
+            'timecreated < :time',
+            ['time' => time() - YEARSECS]
+        );
+    }
+}

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="filter/imageopt/db" VERSION="20180618" COMMENT="XMLDB file for Moodle filter/imageopt"
+<XMLDB PATH="filter/imageopt/db" VERSION="20240131" COMMENT="XMLDB file for Moodle filter/imageopt"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
@@ -7,16 +7,13 @@
     <TABLE NAME="filter_imageopt" COMMENT="Table for tracking image url processing.">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="urlpath" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="urlpath" TYPE="text" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="timeprocessed" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
       </KEYS>
-      <INDEXES>
-        <INDEX NAME="urlpath" UNIQUE="true" FIELDS="urlpath"/>
-      </INDEXES>
     </TABLE>
   </TABLES>
 </XMLDB>

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -15,15 +15,26 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Image Optimiser
- * @author    Guy Thomas <dev@citri.city>
- * @copyright Copyright (c) 2016 Guy Thomas.
- * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package filter_imageopt
+ * @author Andrew Hancox <andrewdchancox@googlemail.com>
+ * @author Open Source Learning <enquiries@opensourcelearning.co.uk>
+ * @link https://opensourcelearning.co.uk
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright 2024, Andrew Hancox
  */
+
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024013101;
-$plugin->requires  = 2011111500;
-$plugin->component = 'filter_imageopt';
-$plugin->maturity  = MATURITY_BETA;
-$plugin->release   = '3.9.0.0';
+$tasks = [
+        [
+                'classname' => '\filter_imageopt\task\expirequeue',
+                'blocking'  => 0,
+                'minute'    => '0',
+                'hour'      => '0',
+                'day'       => '*',
+                'month'     => '*',
+                'dayofweek' => '*',
+                'disabled'  => 0
+        ],
+];
+

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -60,6 +60,25 @@ function xmldb_filter_imageopt_upgrade($oldversion) {
         // Imageopt savepoint reached.
         upgrade_plugin_savepoint(true, 2018061803, 'filter', 'imageopt');
     }
+    if ($oldversion < 2024013100) {
+
+        // Define index urlpath (unique) to be dropped form filter_imageopt.
+        $table = new xmldb_table('filter_imageopt');
+        $index = new xmldb_index('urlpath', XMLDB_INDEX_UNIQUE, ['urlpath']);
+
+        // Conditionally launch drop index urlpath.
+        if ($dbman->index_exists($table, $index)) {
+            $dbman->drop_index($table, $index);
+        }
+
+        $field = new xmldb_field('urlpath', XMLDB_TYPE_TEXT, null, null, XMLDB_NOTNULL, null, null, 'id');
+
+        // Launch change of type for field urlpath.
+        $dbman->change_field_type($table, $field);
+
+        // Imageopt savepoint reached.
+        upgrade_plugin_savepoint(true, 2024013100, 'filter', 'imageopt');
+    }
 
     return true;
 }

--- a/lang/en/filter_imageopt.php
+++ b/lang/en/filter_imageopt.php
@@ -21,6 +21,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 $string['cachedef_public_files'] = 'Cache of public file contenthashes';
+$string['expirequeuetask'] = 'Expire queued images';
 $string['filtername'] = 'Image optimiser';
 $string['maxwidth'] = 'Maximum image width';
 $string['maxwidthdesc'] = 'Maximum image width in pixels';

--- a/tests/filter_test.php
+++ b/tests/filter_test.php
@@ -27,6 +27,7 @@ namespace filter_imageopt;
 defined('MOODLE_INTERNAL') || die();
 
 use context;
+use core_text;
 use moodle_url;
 use stored_file;
 use phpunit_util;
@@ -121,7 +122,11 @@ class filter_test extends advanced_testcase {
 
         $url = phpunit_util::call_internal_method($filter, 'image_opt_url', [$file, $originalurl], get_class($filter));
 
-        $row = $DB->get_record('filter_imageopt', ['urlpath' => 'pluginfile.php/somefile.jpg']);
+        $path = "pluginfile.php/somefile.jpg";
+        $row = $DB->get_record_select(
+            'filter_imageopt',
+            $DB->sql_compare_text('urlpath', core_text::strlen($path)) . "= '{$path}'"
+        );
         $urlpathid = $row->id;
 
         $expected = new moodle_url(

--- a/version.php
+++ b/version.php
@@ -22,7 +22,7 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022020800;
+$plugin->version   = 2024013100;
 $plugin->requires  = 2011111500;
 $plugin->component = 'filter_imageopt';
 $plugin->maturity  = MATURITY_BETA;


### PR DESCRIPTION
As outlined in issue 50:
Moodle file names should not be more than 255 characters, but the filter_imageopt table only allows 255 for the urlpath (filename+other elements). This means that any file name over ~230 characters (substantially less if it contains characters that require urlencoding) prevents the page from rendering.
In order to allow for this situation I have changed the fieldtype to text, this meant I had to drop the unique index on url path as this is not supported on this column type.
To accommodate dropping the index:
I made the add_url_path_to_queue function ignore multiple records as in theory on high traffic sites that could be the case. Multiple rows will not cause an issue though as they will still get mopped up in the normal way by the delete_queue_item_by_path function.
The filter_imageopt table never gets cleared out so large sites can end up with a significant number of entries that were created for images that never ended up being loaded. This would not have been an issue with the unique index in place but without it there is a potential storage issue (the client I'm working with has 14k rows in this table). To mitigate this I now remove all entries over 12 months old.