### PR TITLE
update deprecated and broken tests

### DIFF
--- a/tests/filter_test.php
+++ b/tests/filter_test.php
@@ -270,7 +270,7 @@ class filter_test extends advanced_testcase {
 
         // Test filter plugin img, lazy load.
         $regex = '/img data-loadonvisible="'.str_replace('~pathid~', '(?:[0-9]*)', preg_quote($loadonvisibleurl, '/')).'/';
-        $this->assertMatchesRegularExpression($regex, $str);
+        $this->assertRegExp($regex, $str);
         $this->assertStringContainsString('src="data:image/svg+xml;utf8,', $str);
 
     }
@@ -318,7 +318,7 @@ class filter_test extends advanced_testcase {
 
         $postfilterurl = $this->filter_imageopt_url_from_file($file, $maxwidth);
         $regex = '/'.str_replace('~pathid~', '(?:[0-9]*)', preg_quote($postfilterurl, '/')).'/';
-        $this->assertMatchesRegularExpression($regex, $processed);
+        $this->assertRegExp($regex, $processed);
 
     }
 
@@ -349,7 +349,7 @@ class filter_test extends advanced_testcase {
         $this->assertStringContainsString($prefilterurl, $labeltxt);
         $postfilterurl = $this->filter_imageopt_url_from_file($file, $maxwidth);
         $regex = '/src="'.str_replace('~pathid~', '(?:[0-9]*)', preg_quote($postfilterurl, '/')).'/';
-        $this->assertMatchesRegularExpression($regex, $filtered);
+        $this->assertRegExp($regex, $filtered);
 
         // We need a space before src so it doesn't trigger on original-src.
         $this->assertStringNotContainsString(' src="'.$prefilterurl, $filtered);
@@ -365,7 +365,7 @@ class filter_test extends advanced_testcase {
         $postfilterurl = $this->filter_imageopt_url_from_file($file, $maxwidth);
 
         $regex = '/data-loadonvisible="'.str_replace('~pathid~', '(?:[0-9]*)', preg_quote($postfilterurl, '/')).'/';
-        $this->assertMatchesRegularExpression($regex, $filtered);
+        $this->assertRegExp($regex, $filtered);
 
         $this->assertStringNotContainsString('data-loadonvisible="'.$prefilterurl, $filtered);
         $this->assertStringNotContainsString('src="'.$postfilterurl, $filtered);

--- a/tests/filter_test.php
+++ b/tests/filter_test.php
@@ -96,7 +96,7 @@ class filter_test extends advanced_testcase {
         ];
         foreach ($sizes as $size) {
             $emptyimage = phpunit_util::call_internal_method($filter, 'empty_image', $size, get_class($filter));
-            $this->assertContains('width="'.$size[0].'" height="'.$size[1].'"', $emptyimage);
+            $this->assertStringContainsString('width="'.$size[0].'" height="'.$size[1].'"', $emptyimage);
         }
     }
 
@@ -270,8 +270,8 @@ class filter_test extends advanced_testcase {
 
         // Test filter plugin img, lazy load.
         $regex = '/img data-loadonvisible="'.str_replace('~pathid~', '(?:[0-9]*)', preg_quote($loadonvisibleurl, '/')).'/';
-        $this->assertRegExp($regex, $str);
-        $this->assertContains('src="data:image/svg+xml;utf8,', $str);
+        $this->assertMatchesRegularExpression($regex, $str);
+        $this->assertStringContainsString('src="data:image/svg+xml;utf8,', $str);
 
     }
 
@@ -318,7 +318,7 @@ class filter_test extends advanced_testcase {
 
         $postfilterurl = $this->filter_imageopt_url_from_file($file, $maxwidth);
         $regex = '/'.str_replace('~pathid~', '(?:[0-9]*)', preg_quote($postfilterurl, '/')).'/';
-        $this->assertRegExp($regex, $processed);
+        $this->assertMatchesRegularExpression($regex, $processed);
 
     }
 
@@ -346,29 +346,29 @@ class filter_test extends advanced_testcase {
         $filter = new filter_imageopt($context, []);
         $filtered = $filter->filter($labeltxt);
         $prefilterurl = $CFG->wwwroot.'/pluginfile.php/'.$context->id.'/mod_label/intro/0/testpng_2880x1800.png';
-        $this->assertContains($prefilterurl, $labeltxt);
+        $this->assertStringContainsString($prefilterurl, $labeltxt);
         $postfilterurl = $this->filter_imageopt_url_from_file($file, $maxwidth);
         $regex = '/src="'.str_replace('~pathid~', '(?:[0-9]*)', preg_quote($postfilterurl, '/')).'/';
-        $this->assertRegExp($regex, $filtered);
+        $this->assertMatchesRegularExpression($regex, $filtered);
 
         // We need a space before src so it doesn't trigger on original-src.
-        $this->assertNotContains(' src="'.$prefilterurl, $filtered);
-        $this->assertNotContains('data-loadonvisible="'.$postfilterurl, $filtered);
-        $this->assertNotContains('data-loadonvisible="'.$prefilterurl, $filtered);
+        $this->assertStringNotContainsString(' src="'.$prefilterurl, $filtered);
+        $this->assertStringNotContainsString('data-loadonvisible="'.$postfilterurl, $filtered);
+        $this->assertStringNotContainsString('data-loadonvisible="'.$prefilterurl, $filtered);
 
         // Test filter plugin img,  lazy load.
         set_config('loadonvisible', '0', 'filter_imageopt');
         $filter = new filter_imageopt($context, []);
         $filtered = $filter->filter($labeltxt);
         $prefilterurl = $CFG->wwwroot.'/pluginfile.php/'.$context->id.'/mod_label/intro/0/testpng_2880x1800.png';
-        $this->assertContains($prefilterurl, $labeltxt);
+        $this->assertStringContainsString($prefilterurl, $labeltxt);
         $postfilterurl = $this->filter_imageopt_url_from_file($file, $maxwidth);
 
         $regex = '/data-loadonvisible="'.str_replace('~pathid~', '(?:[0-9]*)', preg_quote($postfilterurl, '/')).'/';
-        $this->assertRegExp($regex, $filtered);
+        $this->assertMatchesRegularExpression($regex, $filtered);
 
-        $this->assertNotContains('data-loadonvisible="'.$prefilterurl, $filtered);
-        $this->assertNotContains('src="'.$postfilterurl, $filtered);
-        $this->assertNotContains('src="'.$prefilterurl, $filtered);
+        $this->assertStringNotContainsString('data-loadonvisible="'.$prefilterurl, $filtered);
+        $this->assertStringNotContainsString('src="'.$postfilterurl, $filtered);
+        $this->assertStringNotContainsString('src="'.$prefilterurl, $filtered);
     }
 }


### PR DESCRIPTION
Updating unit tests. `assertContains` does not work with the string, and is deprecated, replaced with `assertStringContainsString` and the not equivalents. Same with regex tests, also updated and replaced, as `assertRegExp` is deprecated and getting removed from phpunit 10

Tested with php 8.1 and moodle 4.1, however moodle 3.9 uses phpunit 7.5.

`assertStringContainsString` existed in 7.5, however `assertMatchesRegularExpression` had not been added yet.

Happy to re-do the PR without the regex if you want to merge into 3.9, or could create a new 4.1 branch? 